### PR TITLE
Kibana 4.4: Use elasticsearch.url for proxied reqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN rm "/opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml" \
 ADD templates/opt/kibana-4.1.x/ /opt/kibana-${KIBANA_41_VERSION}/config
 ADD templates/opt/kibana-4.4.x/ /opt/kibana-${KIBANA_44_VERSION}/config
 
+ADD patches /patches
+RUN patch -p1 -d /opt/kibana-4.4.1-linux-x64 < /patches/0001-Set-authorization-header-when-connecting-to-ES.patch
+
 # Add script that starts NGiNX in front of Kibana and tails the NGiNX access/error logs.
 ADD bin .
 RUN chmod 700 ./run-kibana.sh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@
 Kibana as an Aptible app. This app automatically detects your Elasticsearch
 version and starts Kibana 4.1 or 4.4 accordingly.
 
-## Installation and Usage
+
+## Security considerations
+
+This app is configured through two environment variables: `AUTH_CREDENTIALS`
+and `DATABASE_URL`. The former is used to authenticate Kibana users, and the
+latter is used to make requests to a backend Elasticsearch instance.
+
+In other words, **any user that can log in to Kibana can execute queries
+against the upstream Elasticsearch instance using Kibana's credentials**.
+
+This is probably what you want if you're deploying Kibana, but it means you
+should make sure you choose strong passwords for `AUTH_CREDENTIALS`.
+
+
+## Installation
 
 To run as an app on Aptible:
 
@@ -62,6 +76,9 @@ To run as an app on Aptible:
     git remote add aptible git@beta.aptible.com:<YOUR_KIBANA_APP_HANDLE>.git
     git push aptible master
     ```
+
+
+## Next steps
 
 You should be up and running now. If you have a default `*.on-aptible.com` VHOST, you're done. If not, add a custom VHOST to expose your Kibaba app to the Internet.
 

--- a/patches/0001-Set-authorization-header-when-connecting-to-ES.patch
+++ b/patches/0001-Set-authorization-header-when-connecting-to-ES.patch
@@ -1,0 +1,47 @@
+From 5b925fdc6691fe725a64ee267a6bd247afc69570 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Wed, 2 Mar 2016 21:49:53 +0100
+Subject: [PATCH 1/1] Set authorization header when connecting to ES
+
+Use the authoriation settings from elasticsearch.url when operating as a
+proxy.
+
+This mirrors the Kibana 4.1 behavior and makes it possible for users to
+use a different password for Kibana and Elasticsearch.
+---
+ src/plugins/elasticsearch/lib/map_uri.js | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/elasticsearch/lib/map_uri.js b/src/plugins/elasticsearch/lib/map_uri.js
+index de78529..988f2d5 100644
+--- a/src/plugins/elasticsearch/lib/map_uri.js
++++ b/src/plugins/elasticsearch/lib/map_uri.js
+@@ -1,5 +1,6 @@
+ var querystring = require('querystring');
+-var resolve = require('url').resolve;
++var parseUrl = require('url').parse;
++
+ module.exports = function mapUri(server, prefix) {
+   var config = server.config();
+   return function (request, done) {
+@@ -9,8 +10,16 @@ module.exports = function mapUri(server, prefix) {
+       if (/\/$/.test(url)) url = url.substring(0, url.length - 1);
+       url += path;
+     }
++
++    var uri = parseUrl(url),
++        headers = {};
++    if (uri.auth) {
++      var auth = new Buffer(uri.auth);
++      headers.authorization = 'Basic ' + auth.toString('base64');
++    }
++
+     var query = querystring.stringify(request.query);
+     if (query) url += '?' + query;
+-    done(null, url);
++    done(null, url, headers);
+   };
+ };
+-- 
+2.7.1
+


### PR DESCRIPTION
Kibana 4.1 uses the credentials provided in the ES URL to authenticate
requests it proxies, which means users don't need to authenticate both
to Kibana and Elasticsearch when making a request to the latter through
the former (which isn't possible in the first place if both are using
basic auth with different credentials).

However, Kibana 4.4 does not do this by default, and proxies the headers
it received as-is to Elasticsearch, which doesn't work if Elasticsearch
uses different credentials (because the user's browser would need to
send the Kibana auth header to get through the Nginx instance proxying
Kibana _and_ the Elasticsearch auth header to get through the one
proxying Elasticsearch).

So, this patch adds a patch for Kibana 4.4 to behave like Kibana 4.1 and
inject the credentials from `elasticsearch.url` when connecting to
Elasticsearch. It also adds some documentation to clarify what's going
on to users (even though nothing _new_ is going on, at least as far as
Kibana 4.1 — which is presumably the only one in use on Aptible
currently — is concerned).

---

cc @fancyremarker , this is a followup from our discussion yesterday.
