### PR TITLE
Fix memory usage problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && \
 ENV KIBANA_41_VERSION 4.1.5
 ENV KIBANA_41_SHA1SUM 7c1e597f69abd2c9c2b4de045350199d8b187a9a
 
-ENV KIBANA_44_VERSION 4.4.1
-ENV KIBANA_44_SHA1SUM b4f1b5d89a0854e3fb1e6d31faa1bc78e063b083
+ENV KIBANA_44_VERSION 4.4.2
+ENV KIBANA_44_SHA1SUM 6251dbab12722ea1a036d8113963183f077f9fa7
 
 # Kibana 4.1
 RUN curl -O "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_41_VERSION}-linux-x64.tar.gz" && \
@@ -40,7 +40,7 @@ ADD templates/opt/kibana-4.1.x/ /opt/kibana-${KIBANA_41_VERSION}/config
 ADD templates/opt/kibana-4.4.x/ /opt/kibana-${KIBANA_44_VERSION}/config
 
 ADD patches /patches
-RUN patch -p1 -d /opt/kibana-4.4.1-linux-x64 < /patches/0001-Set-authorization-header-when-connecting-to-ES.patch
+RUN patch -p1 -d "/opt/kibana-${KIBANA_44_VERSION}-linux-x64" < /patches/0001-Set-authorization-header-when-connecting-to-ES.patch
 
 # Add script that starts NGiNX in front of Kibana and tails the NGiNX access/error logs.
 ADD bin .

--- a/bin/run-kibana.sh
+++ b/bin/run-kibana.sh
@@ -51,4 +51,11 @@ erb -T 2 -r uri "/opt/kibana-${KIBANA_VERSION}/config/kibana.yml.erb" > "/opt/ki
 }
 
 service nginx start
+
+# Default node options to limit Kibana memory usage as per https://github.com/elastic/kibana/issues/5170
+# If this is not set, Node tries to use about 1.5GB of memory before it starts actively garbage collect.
+# shellcheck disable=SC2086
+: ${NODE_OPTIONS:="--max-old-space-size=256"}
+
+export NODE_OPTIONS
 exec "/opt/kibana-${KIBANA_VERSION}-linux-x64/bin/kibana"


### PR DESCRIPTION
By default, Node targets a comfortable 1.5GB of memory usage, which is a
little too much on Aptible. Limit the usage to ensure Kibana doesn't
gets killed.
