### PR TITLE
Support Kibana 5 / Elasticsearch 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,29 +18,43 @@ ENV KIBANA_41_SHA1SUM 13655cf94f5c47e8ab4d94c8170128f63be46ad5
 ENV KIBANA_44_VERSION 4.4.2
 ENV KIBANA_44_SHA1SUM 6251dbab12722ea1a036d8113963183f077f9fa7
 
+ENV KIBANA_5_VERSION 5.0.1
+ENV KIBANA_5_SHA1SUM 66f058017219d23ef5534545f5c6ad1dca4bb1fd
+
 # Kibana 4.1
-RUN curl -O "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_41_VERSION}-linux-x64.tar.gz" && \
+RUN curl -fsSLO "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_41_VERSION}-linux-x64.tar.gz" && \
     echo "${KIBANA_41_SHA1SUM}  kibana-${KIBANA_41_VERSION}-linux-x64.tar.gz" | sha1sum -c - && \
     tar xzf "kibana-${KIBANA_41_VERSION}-linux-x64.tar.gz" -C /opt && \
+    mv "/opt/kibana-${KIBANA_41_VERSION}-linux-x64" "/opt/kibana-${KIBANA_41_VERSION}" && \
     rm "kibana-${KIBANA_41_VERSION}-linux-x64.tar.gz"
 
 # Kibana 4.4
-RUN curl -O "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_44_VERSION}-linux-x64.tar.gz" && \
+RUN curl -fsSLO "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_44_VERSION}-linux-x64.tar.gz" && \
     echo "${KIBANA_44_SHA1SUM}  kibana-${KIBANA_44_VERSION}-linux-x64.tar.gz" | sha1sum -c - && \
     tar xzf "kibana-${KIBANA_44_VERSION}-linux-x64.tar.gz" -C /opt && \
+    mv "/opt/kibana-${KIBANA_44_VERSION}-linux-x64" "/opt/kibana-${KIBANA_44_VERSION}" && \
     rm "kibana-${KIBANA_44_VERSION}-linux-x64.tar.gz"
+
+# Kibana 5
+RUN curl -fsSLO "https://artifacts.elastic.co/downloads/kibana/kibana-${KIBANA_5_VERSION}-linux-x86_64.tar.gz" && \
+    echo "${KIBANA_5_SHA1SUM}  kibana-${KIBANA_5_VERSION}-linux-x86_64.tar.gz" | sha1sum -c - && \
+    tar xzf "kibana-${KIBANA_5_VERSION}-linux-x86_64.tar.gz" -C /opt && \
+    mv "/opt/kibana-${KIBANA_5_VERSION}-linux-x86_64" "/opt/kibana-${KIBANA_5_VERSION}" && \
+    rm "kibana-${KIBANA_5_VERSION}-linux-x86_64.tar.gz"
 
 # Overwrite default nginx config with our config.
 RUN rm /etc/nginx/sites-enabled/*
 ADD templates/sites-enabled /
 
-RUN rm "/opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml" \
- && rm "/opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml"
+RUN rm "/opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml" \
+ && rm "/opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml" \
+ && rm "/opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml"
 ADD templates/opt/kibana-4.1.x/ /opt/kibana-${KIBANA_41_VERSION}/config
 ADD templates/opt/kibana-4.4.x/ /opt/kibana-${KIBANA_44_VERSION}/config
+ADD templates/opt/kibana-5.x/ /opt/kibana-${KIBANA_5_VERSION}/config
 
 ADD patches /patches
-RUN patch -p1 -d "/opt/kibana-${KIBANA_44_VERSION}-linux-x64" < /patches/0001-Set-authorization-header-when-connecting-to-ES.patch
+RUN patch -p1 -d "/opt/kibana-${KIBANA_44_VERSION}" < /patches/0001-Set-authorization-header-when-connecting-to-ES.patch
 
 # Add script that starts NGiNX in front of Kibana and tails the NGiNX access/error logs.
 ADD bin .

--- a/bin/run-kibana.sh
+++ b/bin/run-kibana.sh
@@ -29,14 +29,16 @@ if [[ -z "$KIBANA_ACTIVE_VERSION" ]]; then
   KIBANA_VERSION_PARSER="
   require 'json'
   version = JSON.parse(STDIN.read)['version']['number']
-  print version.start_with?('1.') ? 41 : 44"
+  print 41 if version.start_with?('1.')
+  print 44 if version.start_with?('2.')
+  print 5 if version.start_with?('5.')"
   KIBANA_ACTIVE_VERSION="$(curl "$DATABASE_URL" 2>/dev/null | ruby -e "$KIBANA_VERSION_PARSER" 2>/dev/null)"
 fi
 
 # If we still don't have a version, fall back to the default.
 if [[ -z "$KIBANA_ACTIVE_VERSION" ]]; then
-    echo "Warning: unable to fetch Elasticsearch version, and none configured. Defaulting to 4.4. Consider setting KIBANA_ACTIVE_VERSION."
-    KIBANA_ACTIVE_VERSION="44"
+    echo "Warning: unable to fetch Elasticsearch version, and none configured. Defaulting to 5.x. Consider setting KIBANA_ACTIVE_VERSION."
+    KIBANA_ACTIVE_VERSION="5"
 fi
 
 echo "KIBANA_ACTIVE_VERSION is set to: '$KIBANA_ACTIVE_VERSION'"
@@ -45,7 +47,7 @@ KIBANA_VERSION_PTR="KIBANA_${KIBANA_ACTIVE_VERSION}_VERSION"
 KIBANA_VERSION="${!KIBANA_VERSION_PTR}"
 
 # Run config
-erb -T 2 -r uri "/opt/kibana-${KIBANA_VERSION}/config/kibana.yml.erb" > "/opt/kibana-${KIBANA_VERSION}-linux-x64/config/kibana.yml" || {
+erb -T 2 -r uri "/opt/kibana-${KIBANA_VERSION}/config/kibana.yml.erb" > "/opt/kibana-${KIBANA_VERSION}/config/kibana.yml" || {
   echo "Error creating kibana config file"
   exit 1
 }
@@ -58,4 +60,4 @@ service nginx start
 : ${NODE_OPTIONS:="--max-old-space-size=256"}
 
 export NODE_OPTIONS
-exec "/opt/kibana-${KIBANA_VERSION}-linux-x64/bin/kibana"
+exec "/opt/kibana-${KIBANA_VERSION}/bin/kibana"

--- a/templates/opt/kibana-5.x/kibana.yml.erb
+++ b/templates/opt/kibana-5.x/kibana.yml.erb
@@ -1,0 +1,89 @@
+<% u = URI(ENV['DATABASE_URL']) %>
+<% elasticsearch_url = "#{u.scheme}://#{u.user}:#{u.password}@#{u.host}:#{u.port}" %>
+<% user = "#{u.user}" %>
+<% password = "#{u.password}" %>
+
+# Kibana is served by a back end server. This controls which port to use.
+server.port: 5601
+
+# The host to bind the server to.
+server.host: "0.0.0.0"
+
+# If you are running kibana behind a proxy, and want to mount it at a path,
+# specify that path here. The basePath can't end in a slash.
+# server.basePath: ""
+
+# The maximum payload size in bytes on incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The Elasticsearch instance to use for all your queries.
+elasticsearch.url: "<%= elasticsearch_url %>"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch.preserveHost: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+kibana.index: ".kibana"
+
+# The default application to load.
+kibana.defaultAppId: "discover"
+
+# If your Elasticsearch is protected with basic auth, these are the user credentials
+# used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied through
+# the Kibana server)
+elasticsearch.username: "<%= user %>"
+elasticsearch.password: "<%= password %>"
+
+# SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+# server.ssl.cert: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+# elasticsearch.ssl.cert: /path/to/your/client.crt
+# elasticsearch.ssl.key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsearch instance, put
+# the path of the pem file here.
+# elasticsearch.ssl.ca: /path/to/your/CA.pem
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+elasticsearch.ssl.verify: true
+
+# Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+# request_timeout setting
+# elasticsearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+elasticsearch.requestTimeout: 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+elasticsearch.shardTimeout: 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+# elasticsearch.startupTimeout: 5000
+
+# Set the path to where you would like the process id file to be created.
+# pid.file: /var/run/kibana.pid
+
+# If you would like to send the log output to a file you can set the path below.
+# logging.dest: stdout
+
+# Set this to true to suppress all logging output.
+# logging.silent: false
+
+# Set this to true to suppress all logging output except for error messages.
+# logging.quiet: false
+
+# Set this to true to log all events, including system usage information and all requests.
+# logging.verbose: false
+
+# Don't accept the Authorization header from the client (that's the default),
+# since it would overwrite the header Kibana will generate using the
+# Elasticsearch DB URL.
+elasticsearch.requestHeadersWhitelist: []

--- a/test/kibana.bats
+++ b/test/kibana.bats
@@ -8,8 +8,9 @@ teardown() {
   rm /var/log/nginx/error.log || true
   pkill tcpserver || true
   pkill nc || true
-  rm -f "/opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml"
-  rm -f "/opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml"
+  rm -f "/opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml"
+  rm -f "/opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml"
+  rm -f "/opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml"
 }
 
 @test "docker-kibana requires the AUTH_CREDENTIALS environment variable to be set" {
@@ -57,37 +58,55 @@ teardown() {
 
 @test "docker-kibana sets the elasticsearch url correctly for Kibana 4.1.x" {
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=41 timeout 1 /bin/bash run-kibana.sh || true
-  run grep "elasticsearch_url: \"http://root:admin123@localhost:1234\"" "opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml"
+  run grep "elasticsearch_url: \"http://root:admin123@localhost:1234\"" "opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml"
   [ "$status" -eq 0 ]
 }
 
 @test "docker-kibana sets the elasticsearch username correctly for Kibana 4.1.x" {
  AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=41 timeout 1 /bin/bash run-kibana.sh || true
- run grep "kibana_elasticsearch_username: \"root\"" "opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml"
+ run grep "kibana_elasticsearch_username: \"root\"" "opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml"
  [ "$status" -eq 0 ]
 }
 
 @test "docker-kibana sets the elasticsearch password correctly for Kibana 4.1.x" {
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=41 timeout 1 /bin/bash run-kibana.sh || true
-  run grep "kibana_elasticsearch_password: \"admin123\"" "opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml"
+  run grep "kibana_elasticsearch_password: \"admin123\"" "opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml"
   [ "$status" -eq 0 ]
 }
 
 @test "docker-kibana sets the elasticsearch url correctly for Kibana 4.4.x" {
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=44 timeout 1 /bin/bash run-kibana.sh || true
-  run grep "elasticsearch.url: \"http://root:admin123@localhost:1234\"" "opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml"
+  run grep "elasticsearch.url: \"http://root:admin123@localhost:1234\"" "opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml"
   [ "$status" -eq 0 ]
 }
 
 @test "docker-kibana sets the elasticsearch username correctly for Kibana 4.4.x" {
  AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=44 timeout 1 /bin/bash run-kibana.sh || true
- run grep "elasticsearch.username: \"root\"" "opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml"
+ run grep "elasticsearch.username: \"root\"" "opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml"
  [ "$status" -eq 0 ]
 }
 
 @test "docker-kibana sets the elasticsearch password correctly for Kibana 4.4.x" {
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=44 timeout 1 /bin/bash run-kibana.sh || true
-  run grep "elasticsearch.password: \"admin123\"" "opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml"
+  run grep "elasticsearch.password: \"admin123\"" "opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml"
+  [ "$status" -eq 0 ]
+}
+
+@test "docker-kibana sets the elasticsearch url correctly for Kibana 5.x" {
+  AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=5 timeout 1 /bin/bash run-kibana.sh || true
+  run grep "elasticsearch.url: \"http://root:admin123@localhost:1234\"" "opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml"
+  [ "$status" -eq 0 ]
+}
+
+@test "docker-kibana sets the elasticsearch username correctly for Kibana 5.x" {
+ AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=5 timeout 1 /bin/bash run-kibana.sh || true
+ run grep "elasticsearch.username: \"root\"" "opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml"
+ [ "$status" -eq 0 ]
+}
+
+@test "docker-kibana sets the elasticsearch password correctly for Kibana 5.x" {
+  AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://root:admin123@localhost:1234 KIBANA_ACTIVE_VERSION=5 timeout 1 /bin/bash run-kibana.sh || true
+  run grep "elasticsearch.password: \"admin123\"" "opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml"
   [ "$status" -eq 0 ]
 }
 
@@ -100,21 +119,49 @@ HTTP_RESPONSE_HEAD="HTTP/1.1 200 OK
   # but it doesn't really matter: we're only checking which configuration files get created.
   echo "$HTTP_RESPONSE_HEAD" '{"version": {"number": "1.5.2"}}' | nc -l 456 &
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://localhost:456 run timeout 1 /bin/bash run-kibana.sh
-  [[ ! -f "/opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml" ]]
-  [[ -f "/opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml" ]]
+  [[ ! -f "/opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml" ]]
+  [[ -f "/opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml" ]]
+  [[ ! -f "/opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml" ]]
 }
 
 @test "docker-kibana detects Elasticsearch 2.x" {
   # Same notes as above.
   echo "$HTTP_RESPONSE_HEAD" '{"version": {"number": "2.2.0"}}' | nc -l 456 &
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://localhost:456 run timeout 1 /bin/bash run-kibana.sh
-  [[ -f "/opt/kibana-${KIBANA_44_VERSION}-linux-x64/config/kibana.yml" ]]
-  [[ ! -f "/opt/kibana-${KIBANA_41_VERSION}-linux-x64/config/kibana.yml" ]]
+  [[ ! -f "/opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml" ]]
+  [[ -f "/opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml" ]]
+  [[ ! -f "/opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml" ]]
 }
 
 @test "docker-kibana proxies with credentials to Elasticsearch 2.x" {
   web_log="${BATS_TEST_DIRNAME}/web.log"
   ( while echo "$HTTP_RESPONSE_HEAD" '{"version": {"number": "2.2.0"}}' | nc -l 456; do : ; done ) > "$web_log" &
+  AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://user:pass@localhost:456 /bin/bash run-kibana.sh &
+  # Hit Kibana directly on port 5601
+  until curl "localhost:5601/elasticsearch/.kibana/visualization/_search"; do
+    echo "Waiting for Kibana to come online"
+    sleep 1
+  done
+
+  pkill node
+  pkill nc
+
+  # Check that a authorization header was sent to "Elasticsearch"
+  grep -A8 ".kibana/" "$web_log" | grep -i "Authorization: Basic"
+}
+
+@test "docker-kibana detects Elasticsearch 5.x" {
+  # Same notes as above.
+  echo "$HTTP_RESPONSE_HEAD" '{"version": {"number": "5.0.1"}}' | nc -l 456 &
+  AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://localhost:456 run timeout 1 /bin/bash run-kibana.sh
+  [[ ! -f "/opt/kibana-${KIBANA_44_VERSION}/config/kibana.yml" ]]
+  [[ ! -f "/opt/kibana-${KIBANA_41_VERSION}/config/kibana.yml" ]]
+  [[ -f "/opt/kibana-${KIBANA_5_VERSION}/config/kibana.yml" ]]
+}
+
+@test "docker-kibana proxies with credentials to Elasticsearch 5.x" {
+  web_log="${BATS_TEST_DIRNAME}/web.log"
+  ( while echo "$HTTP_RESPONSE_HEAD" '{"version": {"number": "5.0.1"}}' | nc -l 456; do : ; done ) > "$web_log" &
   AUTH_CREDENTIALS=root:admin123 DATABASE_URL=http://user:pass@localhost:456 /bin/bash run-kibana.sh &
   # Hit Kibana directly on port 5601
   until curl "localhost:5601/elasticsearch/.kibana/visualization/_search"; do


### PR DESCRIPTION
This adds supporting for running Kibana 5 when we detect Elasticsearch 5 (https://github.com/aptible/docker-elasticsearch/pull/26).

This was also a convenient way to check Log Drains continue to work with ES 5 😄 

cc @fancyremarker @blakepettersson 