### PR TITLE
Send correct auth headers for 5.6

### DIFF
--- a/5.6/templates/kibana.yml.erb
+++ b/5.6/templates/kibana.yml.erb
@@ -2,6 +2,7 @@
 <% elasticsearch_url = "#{u.scheme}://#{u.user}:#{u.password}@#{u.host}:#{u.port}" %>
 <% user = "#{u.user}" %>
 <% password = "#{u.password}" %>
+<% auth = Base64.encode64(user + ':' + password).chomp %>
 
 # Kibana is served by a back end server. This controls which port to use.
 server.port: 5601
@@ -87,3 +88,5 @@ elasticsearch.shardTimeout: 0
 # since it would overwrite the header Kibana will generate using the
 # Elasticsearch DB URL.
 elasticsearch.requestHeadersWhitelist: []
+
+elasticsearch.customHeaders: { Authorization: Basic <%= auth %> }

--- a/test-auth.sh
+++ b/test-auth.sh
@@ -33,8 +33,10 @@ function cleanup {
 
 function wait_for_request {
   CONTAINER=$1
+  shift
+
   for _ in $(seq 1 30); do
-    if docker exec -it "$CONTAINER" curl -f -v "$@" > /dev/null 2>&1; then
+    if docker exec -it "$CONTAINER" curl -f -v "$@" >/dev/null 2>&1; then
       return 0
     fi
     sleep 1
@@ -72,10 +74,14 @@ docker run -d --name="$KIBANA_CONTAINER" \
   -e DATABASE_URL="http://${ES_USER}:${ES_PASS}@${ES_IP}:80" \
   -e AUTH_CREDENTIALS="$KIBANA_CREDS" \
   -e TESTING="true" \
-  "$IMG" 
+  "$IMG"
 
 wait_for_request "${KIBANA_CONTAINER}" \
   'http://localhost:5601/elasticsearch/*/_search' \
   -H "kbn-version: $KIBANA_VERSION" \
   -H 'content-type: application/json' \
   --data-binary '{}'
+
+wait_for_request "${KIBANA_CONTAINER}" \
+  'http://localhost:5601/app/kibana' \
+  -H "kbn-version: $KIBANA_VERSION"


### PR DESCRIPTION
Like 6.0+ (and unlike 5.1), Kibana 5.6 requires the authentication header to be set from the user/pass combo in the Elasticsearch URL.