### PR TITLE
Monthly version bumps, add 6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - TAG=6.2
     - TAG=6.3
     - TAG=6.4
+    - TAG=6.5
 
 script:
   - make build

--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,3 +1,3 @@
-export KIBANA_VERSION=5.6.12
+export KIBANA_VERSION=5.6.14
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
-export KIBANA_SHA1SUM=8331475f7e057ae22340913304d17c23067c1cce
+export KIBANA_SHA1SUM=e2ba2f3ca76fdf4b4eb629446f203ebcf7f7e9cd

--- a/6.5/config.mk
+++ b/6.5/config.mk
@@ -1,3 +1,3 @@
-export KIBANA_VERSION=6.4.3
+export KIBANA_VERSION=6.5.3
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-oss-$(KIBANA_VERSION)-linux-x86_64.tar.gz
-export KIBANA_SHA1SUM=3ae5f0bbbc81585f7c84823c6ac3fd1b9e69aeb6
+export KIBANA_SHA1SUM=294c90cca9e342d5994ce83e15cbdc9d0d814443

--- a/6.5/templates/kibana.yml.erb
+++ b/6.5/templates/kibana.yml.erb
@@ -1,0 +1,92 @@
+<% u = URI(ENV['DATABASE_URL']) %>
+<% elasticsearch_url = "#{u.scheme}://#{u.user}:#{u.password}@#{u.host}:#{u.port}" %>
+<% user = "#{u.user}" %>
+<% password = "#{u.password}" %>
+<% auth = Base64.encode64(user + ':' + password).chomp %>
+
+# Kibana is served by a back end server. This controls which port to use.
+server.port: 5601
+
+# The host to bind the server to.
+server.host: "0.0.0.0"
+
+# If you are running kibana behind a proxy, and want to mount it at a path,
+# specify that path here. The basePath can't end in a slash.
+# server.basePath: ""
+
+# The maximum payload size in bytes on incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The Elasticsearch instance to use for all your queries.
+elasticsearch.url: "<%= elasticsearch_url %>"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch.preserveHost: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+kibana.index: ".kibana"
+
+# The default application to load.
+kibana.defaultAppId: "discover"
+
+# If your Elasticsearch is protected with basic auth, these are the user credentials
+# used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied through
+# the Kibana server)
+elasticsearch.username: "<%= user %>"
+elasticsearch.password: "<%= password %>"
+
+# SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+# server.ssl.cert: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+# elasticsearch.ssl.cert: /path/to/your/client.crt
+# elasticsearch.ssl.key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsearch instance, put
+# the path of the pem file here.
+# elasticsearch.ssl.ca: /path/to/your/CA.pem
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+elasticsearch.ssl.verificationMode: full
+
+# Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+# request_timeout setting
+# elasticsearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+elasticsearch.requestTimeout: 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+elasticsearch.shardTimeout: 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+# elasticsearch.startupTimeout: 5000
+
+# Set the path to where you would like the process id file to be created.
+# pid.file: /var/run/kibana.pid
+
+# If you would like to send the log output to a file you can set the path below.
+# logging.dest: stdout
+
+# Set this to true to suppress all logging output.
+# logging.silent: false
+
+# Set this to true to suppress all logging output except for error messages.
+# logging.quiet: false
+
+# Set this to true to log all events, including system usage information and all requests.
+# logging.verbose: false
+
+# Don't accept the Authorization header from the client (that's the default),
+# since it would overwrite the header Kibana will generate using the
+# Elasticsearch DB URL.
+elasticsearch.requestHeadersWhitelist: []
+
+elasticsearch.customHeaders: { Authorization: Basic <%= auth %> }

--- a/6.5/test/kibana-6.5.bats
+++ b/6.5/test/kibana-6.5.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+source /tmp/test/shared.sh
+
+teardown() {
+  cleanup
+}
+
+@test "docker-kibana detects supported Elasticsearch for kibana:${KIBANA_VERSION}" {
+  echo '{"version": {"number": "'"${KIBANA_VERSION}"'"}}' > /tmp/test/index.html
+  ( cd /tmp/test/ && busybox httpd -f -p '127.0.0.1:456' ) &
+  /bin/bash check-es-version.sh http://localhost:456
+}
+
+@test "docker-kibana detects incompatible Elasticsearch versions" {
+  echo '{"version": {"number": "1.0"}}' > /tmp/test/index.html
+  ( cd /tmp/test/ && busybox httpd -f -p '127.0.0.1:456' ) &
+  run /bin/bash check-es-version.sh http://localhost:456
+  [ $(expr "$output" : ".*using the right image: aptible/kibana:4.1") -ne 0 ]
+}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ You might encounter the following errors when attempting to deploy:
 
 ## Available Tags and Compatibility
 
-* `latest`: Currently Kibana 6.2
+* `latest`: Currently Kibana 6.5
+* `6.5`: For Elasticserach 6.5.x
+* `6.4`: For Elasticserach 6.4.x
+* `6.3`: For Elasticserach 6.3.x
 * `6.2`: For Elasticsearch 6.2.x
 * `6.1`: For Elasticsearch 6.1.x
 * `6.0`: For Elasticsearch 6.0.x

--- a/bin/check-es-version.sh
+++ b/bin/check-es-version.sh
@@ -64,7 +64,8 @@ print 6.0 if es_version.start_with?('6.0.')
 print 6.1 if es_version.start_with?('6.1.')
 print 6.2 if es_version.start_with?('6.2.')
 print 6.3 if es_version.start_with?('6.3.')
-print 6.4 if es_version.start_with?('6.4.')"
+print 6.4 if es_version.start_with?('6.4.')
+print 6.5 if es_version.start_with?('6.5.')"
 
 wait_for_request
 

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 6.4
+LATEST_TAG = 6.5

--- a/templates/sites-enabled/kibana.erb
+++ b/templates/sites-enabled/kibana.erb
@@ -3,9 +3,15 @@ server {
 
   server_name           localhost;
 
+
+<% if ENV['AUTH_TESTING'] %>
+# Since we don't terminate TLS in this container, it's impossible to test auth
+# requests with this redirect in place. This allows a better test in `test-auth.sh`
+<% else %>
   if ($http_x_forwarded_proto != 'https') {
     return 301 https://$host$request_uri;
   }
+<% end %>
 
   location / {
     proxy_pass http://localhost:5601;

--- a/test-auth.sh
+++ b/test-auth.sh
@@ -73,15 +73,17 @@ echo "Starting Kibana"
 docker run -d --name="$KIBANA_CONTAINER" \
   -e DATABASE_URL="http://${ES_USER}:${ES_PASS}@${ES_IP}:80" \
   -e AUTH_CREDENTIALS="$KIBANA_CREDS" \
-  -e TESTING="true" \
+  -e AUTH_TESTING="true" \
   "$IMG"
 
 wait_for_request "${KIBANA_CONTAINER}" \
-  'http://localhost:5601/elasticsearch/*/_search' \
+   -u "$KIBANA_CREDS" \
+  'http://localhost:80/elasticsearch/*/_search' \
   -H "kbn-version: $KIBANA_VERSION" \
   -H 'content-type: application/json' \
   --data-binary '{}'
 
 wait_for_request "${KIBANA_CONTAINER}" \
-  'http://localhost:5601/app/kibana' \
+  -u "$KIBANA_CREDS" \
+  'http://localhost:80/app/kibana' \
   -H "kbn-version: $KIBANA_VERSION"


### PR DESCRIPTION
Notably, I updated `test-auth.sh` to _include_ nginx in the test (ie hit port 80 instead of 5601), to ensure the authorization headers are treated as expected, since we add basic auth ourselves in both Kibana and Elasticseach images.  This was required to surface [this issue](https://github.com/elastic/kibana/issues/26651) in testing.


Relies on https://github.com/aptible/docker-elasticsearch/pull/47