### PR TITLE
Add 6.6, version bumps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - TAG=6.3
     - TAG=6.4
     - TAG=6.5
+    - TAG=6.6
 
 script:
   - make build

--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,3 +1,3 @@
-export KIBANA_VERSION=5.6.14
+export KIBANA_VERSION=5.6.15
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
-export KIBANA_SHA1SUM=e2ba2f3ca76fdf4b4eb629446f203ebcf7f7e9cd
+export KIBANA_SHA1SUM=e820450110ca692d54dadac72a3e17600605c4c5

--- a/6.6/config.mk
+++ b/6.6/config.mk
@@ -1,3 +1,3 @@
-export KIBANA_VERSION=6.5.4
+export KIBANA_VERSION=6.6.1
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-oss-$(KIBANA_VERSION)-linux-x86_64.tar.gz
-export KIBANA_SHA1SUM=7a900ef9a66e61bb9a11427fae0e299ccbcf72e4
+export KIBANA_SHA1SUM=716253730f4fe4c48715ca4a9cb2b6f21a99a9f8

--- a/6.6/templates/kibana.yml.erb
+++ b/6.6/templates/kibana.yml.erb
@@ -1,0 +1,92 @@
+<% u = URI(ENV['DATABASE_URL']) %>
+<% elasticsearch_url = "#{u.scheme}://#{u.user}:#{u.password}@#{u.host}:#{u.port}" %>
+<% user = "#{u.user}" %>
+<% password = "#{u.password}" %>
+<% auth = Base64.encode64(user + ':' + password).chomp %>
+
+# Kibana is served by a back end server. This controls which port to use.
+server.port: 5601
+
+# The host to bind the server to.
+server.host: "0.0.0.0"
+
+# If you are running kibana behind a proxy, and want to mount it at a path,
+# specify that path here. The basePath can't end in a slash.
+# server.basePath: ""
+
+# The maximum payload size in bytes on incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The Elasticsearch instance to use for all your queries.
+elasticsearch.url: "<%= elasticsearch_url %>"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch.preserveHost: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+kibana.index: ".kibana"
+
+# The default application to load.
+kibana.defaultAppId: "discover"
+
+# If your Elasticsearch is protected with basic auth, these are the user credentials
+# used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied through
+# the Kibana server)
+elasticsearch.username: "<%= user %>"
+elasticsearch.password: "<%= password %>"
+
+# SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+# server.ssl.cert: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+# elasticsearch.ssl.cert: /path/to/your/client.crt
+# elasticsearch.ssl.key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsearch instance, put
+# the path of the pem file here.
+# elasticsearch.ssl.ca: /path/to/your/CA.pem
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+elasticsearch.ssl.verificationMode: full
+
+# Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+# request_timeout setting
+# elasticsearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+elasticsearch.requestTimeout: 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+elasticsearch.shardTimeout: 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+# elasticsearch.startupTimeout: 5000
+
+# Set the path to where you would like the process id file to be created.
+# pid.file: /var/run/kibana.pid
+
+# If you would like to send the log output to a file you can set the path below.
+# logging.dest: stdout
+
+# Set this to true to suppress all logging output.
+# logging.silent: false
+
+# Set this to true to suppress all logging output except for error messages.
+# logging.quiet: false
+
+# Set this to true to log all events, including system usage information and all requests.
+# logging.verbose: false
+
+# Don't accept the Authorization header from the client (that's the default),
+# since it would overwrite the header Kibana will generate using the
+# Elasticsearch DB URL.
+elasticsearch.requestHeadersWhitelist: []
+
+elasticsearch.customHeaders: { Authorization: Basic <%= auth %> }

--- a/6.6/test/kibana-6.6.bats
+++ b/6.6/test/kibana-6.6.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+source /tmp/test/shared.sh
+
+teardown() {
+  cleanup
+}
+
+@test "docker-kibana detects supported Elasticsearch for kibana:${KIBANA_VERSION}" {
+  echo '{"version": {"number": "'"${KIBANA_VERSION}"'"}}' > /tmp/test/index.html
+  ( cd /tmp/test/ && busybox httpd -f -p '127.0.0.1:456' ) &
+  /bin/bash check-es-version.sh http://localhost:456
+}
+
+@test "docker-kibana detects incompatible Elasticsearch versions" {
+  echo '{"version": {"number": "1.0"}}' > /tmp/test/index.html
+  ( cd /tmp/test/ && busybox httpd -f -p '127.0.0.1:456' ) &
+  run /bin/bash check-es-version.sh http://localhost:456
+  [ $(expr "$output" : ".*using the right image: aptible/kibana:4.1") -ne 0 ]
+}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ You might encounter the following errors when attempting to deploy:
 
 ## Available Tags and Compatibility
 
-* `latest`: Currently Kibana 6.5
+* `latest`: Currently Kibana 6.6
+* `6.6`: For Elasticserach 6.6.x
 * `6.5`: For Elasticserach 6.5.x
 * `6.4`: For Elasticserach 6.4.x
 * `6.3`: For Elasticserach 6.3.x

--- a/bin/check-es-version.sh
+++ b/bin/check-es-version.sh
@@ -65,7 +65,8 @@ print 6.1 if es_version.start_with?('6.1.')
 print 6.2 if es_version.start_with?('6.2.')
 print 6.3 if es_version.start_with?('6.3.')
 print 6.4 if es_version.start_with?('6.4.')
-print 6.5 if es_version.start_with?('6.5.')"
+print 6.5 if es_version.start_with?('6.5.')
+print 6.6 if es_version.start_with?('6.6.')"
 
 wait_for_request
 

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 6.5
+LATEST_TAG = 6.6


### PR DESCRIPTION
Add support for Kibana 6.6, udpate 6.5, and a security fix for 5.6

https://www.elastic.co/guide/en/kibana/5.6/release-notes-5.6.15.html.

Because a new ES version is introduced, the ES PR must be merged first before the test for Kibana 6.6 will pass : https://github.com/aptible/docker-elasticsearch/pull/48