### PR TITLE
Update Kibana versions.

### DIFF
--- a/4.1/config.mk
+++ b/4.1/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=4.1.11
 export KIBANA_DOWNLOAD=https://download.elastic.co/kibana/kibana/kibana-$(KIBANA_VERSION)-linux-x64.tar.gz
 export KIBANA_SHA1SUM=13655cf94f5c47e8ab4d94c8170128f63be46ad5
+export OS_VERSION=14.04

--- a/4.4/config.mk
+++ b/4.4/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=4.4.2
 export KIBANA_DOWNLOAD=https://download.elastic.co/kibana/kibana/kibana-$(KIBANA_VERSION)-linux-x64.tar.gz
 export KIBANA_SHA1SUM=6251dbab12722ea1a036d8113963183f077f9fa7
+export OS_VERSION=14.04

--- a/5.0/config.mk
+++ b/5.0/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=5.0.2
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=c68eb5d3397a0afb7132630f120b1d53724a2fd9
+export OS_VERSION=14.04

--- a/5.1/config.mk
+++ b/5.1/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=5.1.2
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=ba355d63fef6702109ebdbf72d7ebca0451ed7ae
+export OS_VERSION=14.04

--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=5.6.15
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=e820450110ca692d54dadac72a3e17600605c4c5
+export OS_VERSION=14.04

--- a/6.0/config.mk
+++ b/6.0/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=6.0.1
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=89176814fb2e293ef03d542f707767bf21397d6a
+export OS_VERSION=14.04

--- a/6.1/config.mk
+++ b/6.1/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=6.1.4
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=0771029f60c0862042174fbef8336243e12ad445
+export OS_VERSION=14.04

--- a/6.2/config.mk
+++ b/6.2/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=6.2.4
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=1dfe12d2f84710c2ec5c3747c5521f57d291e7a8
+export OS_VERSION=14.04

--- a/6.3/config.mk
+++ b/6.3/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=6.3.2
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-oss-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=83895fbbd510e0bb96df7a81e534f9ce3b8692a4
+export OS_VERSION=14.04

--- a/6.4/config.mk
+++ b/6.4/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=6.4.3
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-oss-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=3ae5f0bbbc81585f7c84823c6ac3fd1b9e69aeb6
+export OS_VERSION=14.04

--- a/6.5/config.mk
+++ b/6.5/config.mk
@@ -1,3 +1,4 @@
 export KIBANA_VERSION=6.5.4
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-oss-$(KIBANA_VERSION)-linux-x86_64.tar.gz
 export KIBANA_SHA1SUM=7a900ef9a66e61bb9a11427fae0e299ccbcf72e4
+export OS_VERSION=14.04

--- a/6.6/config.mk
+++ b/6.6/config.mk
@@ -1,3 +1,4 @@
-export KIBANA_VERSION=6.6.1
+export KIBANA_VERSION=6.6.2
 export KIBANA_DOWNLOAD=https://artifacts.elastic.co/downloads/kibana/kibana-oss-$(KIBANA_VERSION)-linux-x86_64.tar.gz
-export KIBANA_SHA1SUM=716253730f4fe4c48715ca4a9cb2b6f21a99a9f8
+export KIBANA_SHA1SUM=e8b454ec610ac04dbf96beac2996d99704dd2ef3
+export OS_VERSION=14.04

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM quay.io/aptible/ubuntu:14.04
+FROM quay.io/aptible/ubuntu:<%= ENV.fetch 'OS_VERSION' %>
 
 # Install NGiNX.
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You might encounter the following errors when attempting to deploy:
 * `6.2`: For Elasticsearch 6.2.x
 * `6.1`: For Elasticsearch 6.1.x
 * `6.0`: For Elasticsearch 6.0.x
-* `5.6`: For Elasticsearch 5.6.x
+* `5.6`: (EOL 2019-03-11) For Elasticsearch 5.6.x
 * `5.1`: (EOL 2018-06-08) For Elasticsearch 5.1.x
 * `5.0`: (EOL 2018-04-26) For Elasticsearch 5.0.x
 * `4.4`: (EOL 2017-08-02) For Elasticsearch 2.x


### PR DESCRIPTION
Version bump for 6.6, and 5.6 (which is now EOL).

Also, templatizing the Ubuntu version, to be updated next month.