### PR TITLE
Wait longer for ES to respond.

### DIFF
--- a/bin/check-es-version.sh
+++ b/bin/check-es-version.sh
@@ -34,7 +34,7 @@ if [[ -z "$DATABASE_URL" ]]; then
 fi
 
 function wait_for_request {
-  for _ in {1..10}; do
+  for _ in {1..120}; do
     if curl -f "$DATABASE_URL" > /dev/null 2>&1; then
       return 0
     else


### PR DESCRIPTION
With Terraform, it's possible to provision Kibana so quickly after Elasaticsearch that the database isn't ready quite yet. We already have a mechanism here already to wait until the database is healthy, so let's just allow waiting longer.